### PR TITLE
Notification cert needs to be same as p12 cert

### DIFF
--- a/config/passbook.rb
+++ b/config/passbook.rb
@@ -4,5 +4,5 @@ Passbook.configure do |passbook|
   passbook.p12_certificate = 'certificates/p12_certificate.pem'
   passbook.wwdc_cert = 'certificates/wwdr.pem'
   passbook.notification_gateway = 'gateway.push.apple.com'
-  passbook.notification_cert = 'certificates/push_notificfation_certificate.pem'
+  passbook.notification_cert = 'certificates/p12_certificate.pem'
 end


### PR DESCRIPTION
Need to use Pass Type ID cert for APNS to work.  From Apple:

Your server sends the following pieces of information:
The pass type identifier (in the certificate)
The push token (in the communication to the Apple Push Notification service)